### PR TITLE
Build: Ignore all the node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ generated/
 # Release artifact
 release/
 
-# NPM Binaries
-node_modules/fsevents/lib/binding/Release/node-v51-darwin-x64/
+# NPM
+node_modules/
 
 # Emacs
 ## Ignore temp files


### PR DESCRIPTION
Since they can be regenerated with `npm install` or `yarn install`. You may want a lock file though to ensure the exact dependencies though.